### PR TITLE
SIMPLY-3595: Add checks for chunked responses.

### DIFF
--- a/org.librarysimplified.drm.core/src/main/java/org/nypl/drm/core/AdobeAdeptNetProvider.java
+++ b/org.librarysimplified.drm.core/src/main/java/org/nypl/drm/core/AdobeAdeptNetProvider.java
@@ -233,12 +233,13 @@ import java.util.concurrent.atomic.AtomicInteger;
             w += r;
           }
 
-          Assertions.checkInvariant(
-            w == this.content_length,
-            "Written bytes %d == %d",
-            w,
-            this.content_length);
-
+          if (this.content_length >= 0) {
+            Assertions.checkInvariant(
+              w == this.content_length,
+              "Written bytes %d == %d",
+              w,
+              this.content_length);
+          }
         } catch (final IOException e) {
           final AdobeAdeptStreamClientType c = Objects.requireNonNull(this.client);
           c.onError(
@@ -311,10 +312,11 @@ import java.util.concurrent.atomic.AtomicInteger;
           return;
         }
 
-        {
-          this.content_length = this.conn.getContentLength();
-          Stream.LOG_STREAM.debug(
-            "onRequestInfo: reporting size {}", this.content_length);
+        this.content_length = this.conn.getContentLength();
+        Stream.LOG_STREAM.debug(
+          "onRequestInfo: reporting size {}", this.content_length);
+
+        if (this.content_length >= 0) {
           final AdobeAdeptStreamClientType c = Objects.requireNonNull(this.client);
           c.onTotalLengthReady((long) this.content_length);
         }


### PR DESCRIPTION
**What's this do?**

Add checks for chunked http responses (where the client reports the content length as -1) before doing operations that use the content length.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-3595](https://jira.nypl.org/browse/SIMPLY-3595). Passing -1 into functions that expect an actual content length can cause crashes.

**How should this be tested? / Do these changes have associated tests?**

Borrow and return a DPLA ebook, e.g. "The Summer of Impossibilities" by Rachael Allen from Lyrasis Library. The operations should succeed without crashing the app.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this in an older commit of SimplyE. (I can't run it in the latest commit of SimplyE because of [SIMPLY-3529](https://jira.nypl.org/browse/SIMPLY-3529), but I don't think there's any reason to believe it wouldn't work.)